### PR TITLE
Improve database connection handling when environment variables are missing

### DIFF
--- a/server/__tests__/api.test.js
+++ b/server/__tests__/api.test.js
@@ -26,7 +26,7 @@ jest.mock('../models/Inquiry', () => ({
 }));
 
 const createApp = require('../app');
-const connectDb = require('../config/db');
+const { connectDb, disconnectDb } = require('../config/db');
 const Inquiry = require('../models/Inquiry');
 
 let app;
@@ -45,7 +45,7 @@ describe('LuxeAura Salon API', () => {
   });
 
   afterAll(async () => {
-    await mongoose.connection.close();
+    await disconnectDb();
     if (mongoServer) {
       await mongoServer.stop();
     }

--- a/server/server.js
+++ b/server/server.js
@@ -1,16 +1,18 @@
 const http = require('http');
 const path = require('path');
 const dotenv = require('dotenv');
-const connectDb = require('./config/db');
+const { connectDb } = require('./config/db');
 const createApp = require('./app');
 
 dotenv.config({ path: path.join(__dirname, '.env') });
 
 const port = process.env.PORT || 4000;
+const mongoUri =
+  process.env.MONGO_URI || process.env.MONGODB_URI || process.env.DATABASE_URL;
 
 const startServer = async () => {
   try {
-    await connectDb(process.env.MONGO_URI);
+    await connectDb(mongoUri);
     const app = createApp();
     const server = http.createServer(app);
 


### PR DESCRIPTION
## Summary
- resolve the MongoDB connection string from multiple environment variables
- fall back to an in-memory MongoDB instance during non-production runs when no URI is supplied
- add a disconnect helper and update tests to use the shared database utilities

## Testing
- npm test *(fails: jest is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc08e5789c8330acc17f69162cb86a