### PR TITLE
fix: avoid jsx in custom redux provider

### DIFF
--- a/client/src/lib/reactRedux.js
+++ b/client/src/lib/reactRedux.js
@@ -1,11 +1,10 @@
-import { createContext, useContext, useMemo } from 'react';
-import { useSyncExternalStore } from 'react';
+import { createContext, createElement, useContext, useMemo, useSyncExternalStore } from 'react';
 
 const StoreContext = createContext(null);
 
 export const Provider = ({ store, children }) => {
   const value = useMemo(() => store, [store]);
-  return <StoreContext.Provider value={value}>{children}</StoreContext.Provider>;
+  return createElement(StoreContext.Provider, { value }, children);
 };
 
 export const useDispatch = () => {


### PR DESCRIPTION
## Summary
- replace the JSX return in the custom Provider wrapper with React.createElement to avoid build-time parse errors when JSX isn't transformed
- import createElement alongside the other React hooks used by the helper

## Testing
- npm run build --prefix client *(fails: CSS module import reports missing default export)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4547ccdc8330ba83a070a715dac6